### PR TITLE
HW reset and sleep added

### DIFF
--- a/realsense_ros_camera/include/realsense_node_factory.h
+++ b/realsense_ros_camera/include/realsense_node_factory.h
@@ -65,6 +65,7 @@ namespace realsense_ros_camera
         virtual ~RealSenseNodeFactory() {}
 
     private:
+        rs2::device getDevice(std::string& serial_no);
         virtual void onInit() override;
         void tryGetLogSeverity(rs2_log_severity& severity) const;
 

--- a/realsense_ros_camera/launch/rs_multiple_devices.launch
+++ b/realsense_ros_camera/launch/rs_multiple_devices.launch
@@ -1,6 +1,6 @@
 <launch>
-  <arg name="serial_no_camera1"    default="752112070754"/> <!-- Note: Replace with actual serial number -->
-  <arg name="serial_no_camera2"    default="739112060392"/> <!-- Note: Replace with actual serial number -->
+  <arg name="serial_no_camera1" default="746112061000"/> <!-- Note: Replace with actual serial number -->
+  <arg name="serial_no_camera2" default="746112060503"/> <!-- Note: Replace with actual serial number -->
 
   <group ns="camera1">
     <include file="$(find realsense_ros_camera)/launch/includes/nodelet.launch.xml">


### PR DESCRIPTION
- Hardware reset and sleep for 10 seconds to make sure that the reset takes place successfully.
- Using mutex and condition variables is not currently possible because of no support of device specific callbacks.
 - Documented in PR in the latest realsense repo: https://github.com/intel-ros/realsense/pull/455
- HW reset has been suggested as a solution in https://github.com/intel-ros/realsense/issues/314
- These are similar to the realsense dropouts we face on startup. 
- This has been tested on 3 different robots (B4, B5 and B7) by restarting mbot about 20 times for each robot and checking for realsense failure.
- Increases robot software bringup time by about 10 seconds.
- Required upgrading librealsense to 2.15.0-0~realsense0.83 to support hardware reset for multiple devices by @phil-marble 